### PR TITLE
Remove unused dependencies

### DIFF
--- a/tesseract/loader.py
+++ b/tesseract/loader.py
@@ -78,44 +78,6 @@ def feature_reduce(clf, dim):
         exit(-1)
 
 
-def fetch_data(path, subset, year):
-    kept_mask = []
-    X, y, t = read_vectorized_features(path, subset)
-    for i in t:
-        kept_mask.append(True if i.year == year else False)
-    return X[kept_mask], y[kept_mask], t[kept_mask]
-
-
-def read_vectorized_features(data_dir, subset, feature_version=2):
-    """
-    Read vectorized features into memory mapped numpy arrays
-    """
-    extractor = PEFeatureExtractor(feature_version)
-    ndim = extractor.dim
-
-    X_path = os.path.join(data_dir, "X_{}.dat".format(subset))
-    y_path = os.path.join(data_dir, "y_{}.dat".format(subset))
-    y = np.memmap(y_path, dtype=np.float32, mode="r")
-    train_rows = (y != -1)
-    N = y.shape[0]
-    X = np.memmap(X_path, dtype=np.float32, mode="r", shape=(N, ndim))
-    # X = None
-    # y = None
-
-    t_dframe = pd.read_csv(os.path.join(data_dir, "metadata.csv"), index_col=0)
-    t_list = t_dframe['appeared'].to_list()
-    re = {}
-    for i in t_list:
-        if i not in re:
-            re[i] = 1
-        else:
-            re[i] += 1
-    print(re)
-
-    t = np.array([datetime.strptime(date, '%Y-%m').date() for date in t_list])
-    return X[train_rows], y[train_rows], t[train_rows]
-
-
 def load_dates(infile):
     """
     Parses infile for any dates formatted as YYYY/MM/DD, at most one

--- a/tesseract/loader.py
+++ b/tesseract/loader.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import scipy
-from ember import *
 import numpy
 from sklearn.datasets import load_svmlight_file
 from sklearn.feature_extraction import DictVectorizer

--- a/tesseract/transcendent.py
+++ b/tesseract/transcendent.py
@@ -7,7 +7,6 @@ import pickle as pkl
 from sklearn import metrics as mtcs
 import multiprocessing as mp
 from itertools import repeat
-from termcolor import cprint
 
 
 def sort_by_predicted_label(
@@ -891,7 +890,7 @@ def report_results(d, quiet=False):
     def print_and_extend(report_line):
         nonlocal report_str
         if not quiet:
-            cprint(report_line, 'yellow')
+            print(report_line)
         report_str += report_line + '\n'
 
     s = '% kept elements: {:.1f}, % rejected elements: {:.1f}'.format(


### PR DESCRIPTION
When installing `tesseract-ml` for use in another project, I noticed that there are a couple of required packages that are not specified in `setup.py`. This PR removes the following:
- `ember`, which is required only by two functions in `loader.py` which don't seem to be used anywhere else. (`ember`'s `PEFeatureExtractor` class is used in the function `read_vectorized_features()`, which is in turn used by `fetch_data()`.)
- `termcolor`, which was used to colour one set of text only. I have set that print statement back to the usual `print()`, instead of `cprint()`, but if you'd rather we keep the yellow text then I can equally well update `setup.py` to include `termcolor` instead.