### PR TITLE
Allow later scikit-learn versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ _dependencies = [
     'pyparsing==3.0.9',
     'python-dateutil==2.8.1',
     'pytz==2022.1',
-    'scikit-learn==1.1.1',
+    'scikit-learn>=1.1.1,<2.0.0',
     'scipy==1.8.1',
     'seaborn==0.9.0',
     'six==1.11.0',


### PR DESCRIPTION
A small change to allow later verisons of scikit-learn to be used with tesseract-ml. This is needed for an ongoing project, where a later version of scikit-learn is required.